### PR TITLE
Add Flask-based recovery app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# photorec0nstricor
+# Photorec0nstricor
+
+This project provides a simple Flask API for managing drive recovery using
+`photorec`. The application exposes endpoints to list drives and start a
+recovery process. Real-time status updates are sent over a WebSocket using
+`flask_socketio`.
+
+## Usage
+
+Install the dependencies and run `main.py`:
+
+```bash
+pip install flask flask-cors flask-redis flask-socketio redis pexpect
+python main.py
+```
+
+The API will listen on port `5000`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,16 @@
+from flask import Flask
+from flask_cors import CORS
+from flask_redis import FlaskRedis
+from flask_socketio import SocketIO
+
+
+def create_app(config_filename='config.Config'):
+    app = Flask(__name__)
+    app.config.from_object(config_filename)
+    CORS(app)
+    app.config['REDIS_URL'] = "redis://localhost:6379/0"
+    redis_client = FlaskRedis(app)
+    socketio = SocketIO(app, cors_allowed_origins="*")
+    from .routes import main as main_blueprint
+    app.register_blueprint(main_blueprint)
+    return app

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, request, jsonify
+from .utils import sanitize_input, is_valid_drive_path, list_drives
+
+main = Blueprint('main', __name__)
+
+@main.route('/drives', methods=['GET'])
+def get_drives():
+    drives = list_drives()
+    return jsonify(drives)
+
+@main.route('/start_recovery', methods=['POST'])
+def start_recovery():
+    data = request.get_json()
+    drive_path = sanitize_input(data.get('drive_path', ''))
+    if not is_valid_drive_path(drive_path):
+        return jsonify({'error': 'Invalid drive path'}), 400
+    return jsonify({'message': 'Recovery process started'}), 202

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,14 @@
+import re
+import os
+
+
+def sanitize_input(input_str):
+    return re.sub(r'[^a-zA-Z0-9_\-\./]', '', input_str)
+
+
+def is_valid_drive_path(path):
+    return os.path.exists(path)
+
+
+def list_drives():
+    return [f"/dev/{d}" for d in os.listdir("/dev") if d.startswith("sd")]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,54 @@
+from flask import Flask, jsonify, request
+from flask_socketio import SocketIO, emit
+import subprocess
+import shlex
+from threading import Thread
+import redis
+import json
+from pexpect import spawn
+import re
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'your_secret_key'
+socketio = SocketIO(app, cors_allowed_origins="*")
+redis_client = redis.Redis(host='localhost', port=6379, db=0, decode_responses=True)
+
+
+def sanitize_input(input_str):
+    return re.sub(r'[^a-zA-Z0-9_\-\./]', '', input_str)
+
+
+@socketio.on('connect', namespace='/recovery')
+def test_connect():
+    emit('response', {'message': 'Connected to recovery status updates'})
+
+
+def start_photorec(drive_path):
+    command = f"photorec {shlex.quote(drive_path)}"
+    process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    def emit_output(process):
+        for line in process.stdout:
+            socketio.emit('recovery_update', {'data': line}, namespace='/recovery')
+        process.wait()
+        socketio.emit('recovery_update', {'data': 'Recovery process completed'}, namespace='/recovery')
+
+    thread = Thread(target=emit_output, args=(process,))
+    thread.start()
+    return "Photorec recovery process started."
+
+
+@app.route('/api/start_recovery', methods=['POST'])
+def api_start_recovery():
+    settings_str = redis_client.get('recovery_options')
+    if settings_str is None:
+        return jsonify({'message': "Recovery settings not found."}), 404
+    settings = json.loads(settings_str)
+    recovery_path = sanitize_input(settings.get('recovery_path', ''))
+    drive = sanitize_input(settings.get('drive', ''))
+    message = start_photorec(drive_path=drive)
+    return jsonify({'message': message}), 202
+
+
+if __name__ == '__main__':
+    socketio.run(app, debug=True, port=5000)


### PR DESCRIPTION
## Summary
- add flask app scaffolding
- expose endpoints for listing drives and starting a recovery job
- document how to run the app

## Testing
- `python3 -m py_compile main.py app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4625290083268a18a09217836006