### PR TITLE
Add Flask recovery service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+RUN apt-get update && apt-get install -y testdisk \
+    && pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 5000
+CMD ["python", "-m", "app.main"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # photorec0nstricor
+
+This project provides a simple Flask interface around PhotoRec to allow
+starting recovery jobs and streaming their progress via SocketIO.
+
+## Usage
+
+Run the application with Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+The API exposes an endpoint `/start_recovery` that expects a JSON body
+with a `drive_path` field pointing to a valid `/dev` device.
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,12 @@
+from flask import Flask
+from flask_redis import FlaskRedis
+from flask_socketio import SocketIO
+
+app = Flask(__name__)
+app.config['REDIS_URL'] = "redis://redis:6379/0"
+redis_client = FlaskRedis(app)
+socketio = SocketIO(app, cors_allowed_origins="*")
+
+# Import routes after app creation
+from app import routes  # noqa: E402
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,5 @@
+from app import app, socketio
+
+if __name__ == '__main__':
+    socketio.run(app, host='0.0.0.0', port=5000)
+

--- a/app/recovery.py
+++ b/app/recovery.py
@@ -1,0 +1,30 @@
+import subprocess
+import shlex
+from threading import Thread
+from app import socketio
+
+
+def emit_recovery_status(update: str) -> None:
+    """Emit status updates via SocketIO."""
+    socketio.emit('recovery_update', {'data': update}, namespace='/recovery')
+
+
+def start_recovery_process(drive_path: str) -> None:
+    """Run PhotoRec in a separate thread and stream updates."""
+
+    def recovery_task():
+        cmd = f"photorec /log /d /output {shlex.quote(drive_path)}"
+        process = subprocess.Popen(
+            shlex.split(cmd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        if process.stdout:
+            for line in process.stdout:
+                emit_recovery_status(line.strip())
+
+        emit_recovery_status('Recovery process completed')
+
+    Thread(target=recovery_task, daemon=True).start()

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,17 @@
+from flask import request, jsonify
+from app import app
+from app.recovery import start_recovery_process
+from app.utils import is_valid_drive_path, sanitize_input
+
+
+@app.route('/start_recovery', methods=['POST'])
+def start_recovery():
+    data = request.get_json() or {}
+    drive_path = data.get('drive_path')
+
+    if not drive_path or not is_valid_drive_path(drive_path):
+        return jsonify({'error': 'Invalid drive path'}), 400
+
+    sanitized_drive = sanitize_input(drive_path)
+    start_recovery_process(sanitized_drive)
+    return jsonify({'message': 'Recovery started'}), 202

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,12 @@
+import re
+import shlex
+
+
+def sanitize_input(input_str: str) -> str:
+    """Sanitize strings to avoid shell injection."""
+    return shlex.quote(input_str)
+
+
+def is_valid_drive_path(drive_path: str) -> bool:
+    """Validate that the drive path resembles a /dev/ entry."""
+    return bool(re.match(r"^/dev/[a-zA-Z0-9]+$", drive_path))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - .:/app
+      - /dev:/dev:ro
+    environment:
+      - FLASK_APP=app/main.py
+      - FLASK_ENV=development
+    depends_on:
+      - redis
+  redis:
+    image: redis:alpine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+flask-redis
+flask-socketio


### PR DESCRIPTION
## Summary
- add minimal Flask app to handle recovery via PhotoRec
- stream recovery logs over SocketIO
- provide Dockerfile and docker-compose setup
- document running instructions

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687f491880dc83269181989462cb0756