### PR TITLE
Update README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,56 @@
-A lightweight Flask API wrapping [PhotoRec](https://www.cgsecurity.org/). It exposes endpoints to list available drives and to start a recovery process. Progress messages are streamed to connected clients via Socket.IO.
+A lightweight Flask API wrapping [PhotoRec](https://www.cgsecurity.org/). It exposes endpoints to list available drives and start a recovery process. Progress messages are streamed to connected clients via Socket.IO.
 
-This project provides a simple Flask interface around PhotoRec to allow
-starting recovery jobs and streaming their progress via SocketIO.
+The project includes a minimal Node.js server which serves the React frontend and can forward WebSocket commands to a Docker container.
 
+## Architecture
 
-## Usage
+- **Flask API** (`app/`): Handles `/drives` and `/start_recovery`. When a recovery job runs, PhotoRec output is emitted on the `/recovery` Socket.IO namespace.
+- **Node server** (`node_server.js`): Serves the built React files and exposes a WebSocket server on port `8080` for Docker commands.
+- **Frontend** (`frontend/`): A React interface that selects a drive and displays live recovery logs from the Flask server.
 
-### Docker
+## Running with Docker
+
+1. Build and start the API (and Redis) using Docker Compose:
 
 ```bash
 docker-compose up --build
 ```
 
-### Local
+2. In another terminal, install Node dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+The Flask API listens on `http://localhost:5000`. The Node server hosts the frontend at `http://localhost:3000` and accepts WebSocket connections on `ws://localhost:8080`.
+
+## Running locally without Docker
+
+1. Install Python requirements and start the Flask API:
 
 ```bash
 pip install -r requirements.txt
 python -m app.main
 ```
 
-## Node WebSocket Server
-
-A simple Node.js server using Express and `ws` serves the React frontend and forwards commands to a Docker container. Install the dependencies and run:
+2. In a separate terminal, start the Node server:
 
 ```bash
 npm install
 npm start
 ```
-The recovery process can be started by POSTing to `/start_recovery`.
-=======
-The API exposes an endpoint `/start_recovery` that expects a JSON body
-with a `drive_path` field pointing to a valid `/dev` device.
 
+Navigate to `http://localhost:3000` to use the frontend.
+
+### API usage
+
+Send a POST request to `/start_recovery` with JSON containing `drive_path` (e.g. `/dev/sda`):
+
+```bash
+curl -X POST http://localhost:5000/start_recovery \
+     -H 'Content-Type: application/json' \
+     -d '{"drive_path": "/dev/sda"}'
+```
+
+Progress updates will stream to connected clients under the `/recovery` namespace.


### PR DESCRIPTION
## Summary
- fix merge artifact and extend README
- document Flask API and Node server interaction
- provide Docker and local run instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4f5446fc83269c54d047b2a98a99