### PR TITLE
Allow partition drive paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ npm start
 The recovery process can be started by POSTing to `/start_recovery`.
 =======
 The API exposes an endpoint `/start_recovery` that expects a JSON body
-with a `drive_path` field pointing to a valid `/dev` device.
+with a `drive_path` field pointing to a valid `/dev` device or partition
+(e.g., `/dev/sda` or `/dev/sda1`).
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -9,8 +9,8 @@ def sanitize_input(input_str: str) -> str:
 
 
 def is_valid_drive_path(drive_path: str) -> bool:
-    """Validate that the drive path resembles a block device."""
-    return re.match(r'^/dev/sd[a-z]$', drive_path) is not None
+    """Validate that the drive path resembles a block device or partition."""
+    return re.match(r'^/dev/sd[a-z]\d*$', drive_path) is not None
 
 
 def validate_path(path: str, path_type: str) -> Tuple[bool, str]:


### PR DESCRIPTION
## Summary
- allow /dev/sdXY style partition names when validating drive paths
- document in README that partitions can be provided to `/start_recovery`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f4f62d84483268f5df6cb832d4802