### PR TITLE
Add websocket server to compose

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY node_server.js ./
+COPY frontend ./frontend
+RUN if [ -f frontend/package.json ]; then cd frontend && npm ci && npm run build && cd ..; fi
+EXPOSE 3000 8080
+CMD ["node", "node_server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,17 @@ services:
       - redis
   redis:
     image: redis:alpine
+
+  websocket:
+    build:
+      context: .
+      dockerfile: Dockerfile.node
+    command: node node_server.js
+    ports:
+      - "3000:3000"
+      - "8080:8080"
+    volumes:
+      - .:/app
+      - ./frontend/build:/app/frontend/build
+    depends_on:
+      - web


### PR DESCRIPTION
## Summary
- run Node socket server in its own container
- expose ports for the websocket and Express server
- mount the frontend build and include a Node build file

## Testing
- `npm install`
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4f6657888326b543730bf4f6917d