### PR TITLE
Fix README and websocket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,34 +36,17 @@ python -m app.main
 
 ## Node Socket.IO Server
 
-A small Node.js server now uses Socket.IO to serve the React frontend and forward commands to a Docker container. Install the dependencies and run:
-=======
-
-## Node Socket.IO Server
-
-A small Node.js server now uses Socket.IO to serve the React frontend and forward commands to a Docker container. Install the dependencies and run:
-=======
-2. In a separate terminal, start the Node server:
-
-
+A small Node.js server serves the React frontend and forwards commands to a
+Docker container. Start it in another terminal:
 
 ```bash
 npm install
 npm start
 ```
 
-The recovery process can be started by POSTing to `/start_recovery`.
-
-The endpoint expects a JSON body with a `drive_path` field pointing to a valid
-`/dev` device.
-=======
-The API exposes an endpoint `/start_recovery` that expects a JSON body
-with a `drive_path` field pointing to a valid `/dev` device or partition
-(e.g., `/dev/sda` or `/dev/sda1`).
-
-WebSocket communication happens via Socket.IO on the same port. Clients
-can emit a `command` event and listen for `output` messages.
-
+The recovery process can be started by POSTing to `/start_recovery`. The
+endpoint expects a JSON body with a `drive_path` field (e.g. `/dev/sda`).
+WebSocket messages stream progress under the `/recovery` namespace.
 
 Navigate to `http://localhost:3000` to use the frontend.
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,7 +4,7 @@ import RecoverySettings from './components/RecoverySettings';
 import io from 'socket.io-client';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:5000';
-const socket = io(backendUrl.replace(/^http/, 'ws'), { secure: true });
+const socket = io(`${backendUrl.replace(/^http/, 'ws')}/recovery`, { secure: true });
 
 function App() {
   const [recoveryUpdates, setRecoveryUpdates] = useState([]);

--- a/node_server.js
+++ b/node_server.js
@@ -2,60 +2,46 @@ const express = require('express');
 const http = require('http');
 const path = require('path');
 const { Server } = require('socket.io');
-const { exec } = require('child_process');
-
-const { WebSocketServer } = require('ws');
 const { spawn } = require('child_process');
 
 function sanitizeArgs(data) {
-  const str = data.toString().trim();
+  const str = String(data).trim();
   if (!/^[a-zA-Z0-9_\-./ ]*$/.test(str)) {
     return null;
   }
   return str.length > 0 ? str.split(/\s+/) : [];
 }
 
-
 const app = express();
 const port = 3000;
 
-// Serve the static files from the React app
 app.use(express.static(path.join(__dirname, 'frontend/build')));
 const server = http.createServer(app);
 const io = new Server(server, { cors: { origin: '*' } });
 
 io.on('connection', (socket) => {
   socket.on('command', (data) => {
-    console.log('received: %s', data);
-
-    exec(`docker run --rm recovery-tool ${data}`, (err, stdout, stderr) => {
-      if (err) {
-        socket.emit('output', `Error: ${stderr}`);
-        return;
-      }
-      socket.emit('output', `Output: ${stdout}`);
-
     const args = sanitizeArgs(data);
     if (!args) {
-      ws.send('Error: invalid characters in command');
+      socket.emit('output', 'Error: invalid characters in command');
       return;
     }
+
     const cmd = spawn('docker', ['run', '--rm', 'recovery-tool', ...args]);
     let stdout = '';
     let stderr = '';
-    cmd.stdout.on('data', chunk => {
+    cmd.stdout.on('data', (chunk) => {
       stdout += chunk;
     });
-    cmd.stderr.on('data', chunk => {
+    cmd.stderr.on('data', (chunk) => {
       stderr += chunk;
     });
-    cmd.on('close', code => {
+    cmd.on('close', (code) => {
       if (code !== 0) {
-        ws.send(`Error: ${stderr}`);
+        socket.emit('output', `Error: ${stderr}`);
       } else {
-        ws.send(`Output: ${stdout}`);
+        socket.emit('output', `Output: ${stdout}`);
       }
-      
     });
   });
 });
@@ -63,3 +49,4 @@ io.on('connection', (socket) => {
 server.listen(port, () => {
   console.log(`Server listening on port ${port}`);
 });
+


### PR DESCRIPTION
## Summary
- clean up README duplication
- connect React app to `/recovery` namespace
- simplify websocket server implementation

## Testing
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f79b616388326a03ecd47722ef51e